### PR TITLE
hg38 demo: Debugging update for extreme eigenvalues

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -13,4 +13,4 @@
 
 Most data not already hosted by a public resource (e.g., UCSC Genome Browser, ENCODE Data Hub) has been stored in a Google Bucket (`gs://dsmap/`).  
 
-Note that GCP permissions will be required to access the contents of this bucket. For permissions to access this bucket, please [email Ryan Collins](mailto:rlcollins@g.harvard.edu)  
+Note that GCP permissions will be required to access the contents of this bucket. For permissions to access this bucket, please [email Ryan Collins](mailto:rcollins@broadinstitute.org)  

--- a/data/athena/README.md
+++ b/data/athena/README.md
@@ -17,9 +17,11 @@ Additional details for each dataset are provided in the table below:
 ### Athena hg38 neutral region mask  
 This mask reflects the union of:  
 
-1. Mammalian conserved regions per 91-way GERP (downloaded from Ensembl v103), and
+1. Mammalian conserved regions per 91-way GERP (downloaded from Ensembl v103), 
 
-2. Exons from genes with any marginal evidence of constraint against coding variants.  
+2. Constrained 1kb windows of the genome from gnomAD v3.1 (Z > 3), and
+
+3. Exons from genes with any marginal evidence of constraint against coding variants.  
 
 Specifically, the exons in `2` were taken from any transcript in Gencode v37 with:  
 *  observed/expected loss-of-function variants < 1 in gnomAD v2.1.1, or

--- a/wdls/BinAndAnnotateGenome.wdl
+++ b/wdls/BinAndAnnotateGenome.wdl
@@ -56,6 +56,7 @@ workflow BinAndAnnotateGenome {
 
     # Dockers
     String athena_docker
+    String athena_docker_dev #TODO: REVERT THIS TO athena_docker ONCE DEBUGGING COMPLETE
     String athena_cloud_docker
 
     # Runtime overrides
@@ -185,7 +186,7 @@ workflow BinAndAnnotateGenome {
         max_pcs=max_pcs,
         transformations_tsv=feature_transformations_tsv,
         prefix=prefix,
-        athena_docker=athena_docker,
+        athena_docker=athena_docker_dev,
         runtime_attr_override=runtime_attr_learn_pca
     }
 
@@ -210,7 +211,7 @@ workflow BinAndAnnotateGenome {
           contig=contig,
           shard_size=pairs_per_shard_apply_pca,
           prefix="~{prefix}.pairs",
-          athena_docker=athena_docker,
+          athena_docker=athena_docker_dev,
           runtime_attr_chrom_shard=runtime_attr_chrom_shard,
           runtime_attr_apply_pca=runtime_attr_apply_pca,
           runtime_attr_merge_pairs=runtime_attr_merge_pairs
@@ -375,8 +376,8 @@ task LearnPCA {
 
     # Learn PCA transformation with athena
     athena_cmd="athena eigen-bins $athena_options --bgzip"
-    athena_cmd="$athena_cmd --parameters-outfile ~{prefix}.pca_model.pkl"
-    athena_cmd="$athena_cmd --whiten --fill-missing mean"
+    athena_cmd="$athena_cmd --parameters-outfile ~{prefix}.pca_model.pkl --whiten"
+    athena_cmd="$athena_cmd --cap-predictions --symmetric-cap --fill-missing mean"
     athena_cmd="$athena_cmd --stats ~{prefix}.pca_stats.txt ~{sampled_pairs}"
     echo -e "Now learning PCA decomposition using command:\n$athena_cmd"
     eval $athena_cmd

--- a/wdls/MakeAndAnnotatePairsSingleChrom.wdl
+++ b/wdls/MakeAndAnnotatePairsSingleChrom.wdl
@@ -283,7 +283,7 @@ task AnnotatePairs {
     athena_cmd="athena annotate-pairs --bgzip --no-ucsc-chromsplit $athena_options"
     athena_cmd="$athena_cmd ~{pairs} ~{out_prefix}.annotated.pairs.bed.gz"
     echo -e "Now pairing bins using command:\n$athena_cmd"
-    eval $athena_cmd 2> >(fgrep -v "is marked as paired, but its mate does not occur" >&2)
+    eval $athena_cmd
     tabix -f ~{out_prefix}.annotated.pairs.bed.gz
   }
 

--- a/wdls/MakeSitesVcf.wdl
+++ b/wdls/MakeSitesVcf.wdl
@@ -1,0 +1,93 @@
+#######################
+#    DSMap Project    #
+#######################
+#
+# MakeSitesVcf.wdl
+#
+# Helper workflow to make a sites VCF from one or more VCFs
+#
+# Copyright (c) 2023-Present Ryan L. Collins and the Talkowski Laboratory
+# Distributed under terms of the MIT License (see LICENSE)
+# Contact: Ryan L. Collins <rcollins@broadinstitute.org>
+
+
+version 1.0
+
+import "Structs.wdl"
+
+
+workflow MakeSitesVcf {
+  input {
+    Array[File] vcfs
+    Array[File] vcf_idxs
+
+    String athena_docker
+
+    RuntimeAttr? runtime_attr_override
+  }
+
+  scatter ( vcf_info in zip(vcfs, vcf_idxs) ) {
+
+    File vcf = vcf_info.left
+    File vcf_idx = vcf_info.right
+    String out_filename = basename(vcf, ".vcf.gz") + ".sites.vcf.gz"
+
+    call MakeSites {
+      input:
+        vcf=vcf,
+        vcf_idx=vcf_idx,
+        out_filename=out_filename,
+        athena_docker=athena_docker,
+        runtime_attr_override=runtime_attr_override
+    }
+  }
+
+  output {
+    Array[File] sites_vcfs = MakeSites.vcf_out
+    Array[File] sites_vcf_idxs = MakeSites.vcf_idx_out
+  }
+}
+
+
+task MakeSites {
+  input {
+    File vcf
+    File vcf_idx
+    String out_filename
+    String athena_docker
+    RuntimeAttr? runtime_attr_override
+  }
+  RuntimeAttr default_attr = object {
+    cpu_cores: 1, 
+    mem_gb: 4,
+    disk_gb: ceil(3 * size([vcf], "GB")) + 20,
+    boot_disk_gb: 10,
+    preemptible_tries: 3,
+    max_retries: 1
+  }
+  RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
+
+  command {
+
+    set -euo pipefail
+
+    zcat ~{vcf} | cut -f1-8 | bgzip -c > ~{out_filename}
+    tabix -p vcf -f ~{out_filename}
+
+  }
+
+  output {
+    File vcf_out = "~{out_filename}"
+    File vcf_idx_out = "~{out_filename}.tbi"
+  }
+  
+  runtime {
+    cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])
+    memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
+    disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " HDD"
+    bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, default_attr.boot_disk_gb])
+    docker: athena_docker
+    preemptible: select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
+    maxRetries: select_first([runtime_attr.max_retries, default_attr.max_retries])
+  }
+}

--- a/wdls/TrainMuModel.wdl
+++ b/wdls/TrainMuModel.wdl
@@ -198,10 +198,10 @@ task IntersectSVs {
     tabix -h ~{vcf} ~{contig} | bgzip -c > ~{prefix}.~{contig}.svs.vcf.gz
 
     # Intersect variants and pairs with athena
-    athena_cmd="athena count-sv --bin-format pairs --comparison breakpoint"
+    athena_cmd="athena count-sv --query-format pairs --comparison breakpoint"
     athena_cmd="$athena_cmd --probabilities --bgzip"
+    athena_cmd="$athena_cmd --outfile ~{prefix}.pairs.wCounts.~{contig}.bed.gz"
     athena_cmd="$athena_cmd ~{prefix}.~{contig}.svs.vcf.gz ~{pairs_bed}"
-    athena_cmd="$athena_cmd ~{prefix}.pairs.wCounts.~{contig}.bed.gz"
     echo -e "Now intersecting SVs and bins using command:\n$athena_cmd"
     eval $athena_cmd
     tabix -f ~{prefix}.pairs.wCounts.~{contig}.bed.gz


### PR DESCRIPTION
Major changes:

- Added `MakeSitesVcf.wdl` for creating SV sites VCF from gnomAD SV intermediate files before final gnomAD SV VCF was ready
- Added filter on noncoding Z-score constraint to neutral site selection criteria
- Added `--cap-predictions` and `--symmetric-cap` flags when doing PCA transformation with `athena eigen-bins`

Minor changes:

- Added parameter `athena_docker_dev` to `BinAndAnnotateGenome.wdl` (to be removed once debugging dev work done)
- Adjusted `--bin-format` to `--query-format` in call to `athena count-sv`
- Removed report of `"is marked as paired, but its mate does not occur"` when annotating pairs with `athena annotate-pairs` in `MakeAndAnnotatePairsSingleChrom.wdl`